### PR TITLE
changed max length of description field to be 500 char

### DIFF
--- a/tripscribe/src/pages/addTrip/addTripForm.jsx
+++ b/tripscribe/src/pages/addTrip/addTripForm.jsx
@@ -18,7 +18,7 @@ export const AddTripForm = () => {
     const [modalIsOpen, setModalIsOpen] = useState(false);
     const [images, setImages] = useState([]); // State to hold images
     const [urls, setUrls] = useState([]); // State to hold the uploaded image URLs
-    const maxLength = 200;
+    const maxLength = 500;
     const navigate = useNavigate();// Initialize the useNavigate hook
 
     const handleDescriptionChange = (e) => {


### PR DESCRIPTION
Increased maximum length of trip description to 500 characters (in AddTripForm)

This will now mean that on MyTrips, only the first 250 will be shown on the small cards BUT on TripDetails all 500 characters will shown on the larger view.