### PR TITLE
navbar logout link changed

### DIFF
--- a/tripscribe/src/components/responsiveNavbar/responsiveNavbar.jsx
+++ b/tripscribe/src/components/responsiveNavbar/responsiveNavbar.jsx
@@ -25,7 +25,7 @@ const pageLinks = {
 const settings = ['Profile', 'Logout'];
 const settingsLinks = {
   'Profile': '/userprofile',
-  'Logout': '/logout',
+  'Logout': '/',
 };
 
 function ResponsiveNavbar() {


### PR DESCRIPTION
Navbar logout link now redirects to "/" (the page for login or register).
Previously went nowhere.